### PR TITLE
Added JSON Lines and Cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ $ subjs -h
 | `-ua` | User-Agent to send in requests | `subjs -ua "Chrome..."` |
 | `-version` | Show version number | `subjs -version"` |
 | `-jsl` | JSON Lines output (contains source url as well) | `subjs -jsl`|
+| `-cookie` | Cookie to send in requests | `subjs -cookie "JSESSIONID...` |
 
 ## Installation
 ### From Source:
 
 ```
-$ GO111MODULE=on go get -u -v github.com/lc/subjs@latest
+$ GO111MODULE=on go install -v github.com/lc/subjs@latest
 ```
 
 ### From Binary

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ subjs -h
 | `-t` | Timeout (in seconds) for http client (default 15) | `subjs -t 20` |
 | `-ua` | User-Agent to send in requests | `subjs -ua "Chrome..."` |
 | `-version` | Show version number | `subjs -version"` |
-
+| `-jsl` | JSON Lines output (contains source url as well) | `subjs -jsl`|
 
 ## Installation
 ### From Source:

--- a/runner/subjs/options.go
+++ b/runner/subjs/options.go
@@ -11,6 +11,7 @@ type Options struct {
 	Workers   int
 	Timeout   int
 	UserAgent string
+	JSONLines bool
 }
 
 func ParseOptions() *Options {
@@ -19,6 +20,7 @@ func ParseOptions() *Options {
 	flag.StringVar(&opts.UserAgent, "ua", "", "User-Agent to send in requests")
 	flag.IntVar(&opts.Workers, "c", 10, "Number of concurrent workers")
 	flag.IntVar(&opts.Timeout, "t", 15, "Timeout (in seconds) for http client")
+	flag.BoolVar(&opts.JSONLines, "jsl", false, "JSON Lines output")
 	showVersion := flag.Bool("version", false, "Show version number")
 	flag.Parse()
 	if *showVersion {

--- a/runner/subjs/options.go
+++ b/runner/subjs/options.go
@@ -12,12 +12,14 @@ type Options struct {
 	Timeout   int
 	UserAgent string
 	JSONLines bool
+	Cookie string
 }
 
 func ParseOptions() *Options {
 	opts := &Options{}
 	flag.StringVar(&opts.InputFile, "i", "", "Input file containing URLS")
 	flag.StringVar(&opts.UserAgent, "ua", "", "User-Agent to send in requests")
+	flag.StringVar(&opts.Cookie, "cookie", "", "Cookie to send in requests")
 	flag.IntVar(&opts.Workers, "c", 10, "Number of concurrent workers")
 	flag.IntVar(&opts.Timeout, "t", 15, "Timeout (in seconds) for http client")
 	flag.BoolVar(&opts.JSONLines, "jsl", false, "JSON Lines output")

--- a/runner/subjs/runner.go
+++ b/runner/subjs/runner.go
@@ -89,6 +89,9 @@ func (s *SubJS) fetch(urls <-chan string, results chan string) {
 		if s.opts.UserAgent != "" {
 			req.Header.Add("User-Agent", s.opts.UserAgent)
 		}
+		if s.opts.Cookie != "" {
+			req.Header.Add("Cookie", s.opts.Cookie)
+		}
 		resp, err := s.client.Do(req)
 		if err != nil {
 			continue


### PR DESCRIPTION
Hi Corben,

Thanks for sharing this tool with the community!

I needed a few things so I added them. If you think they're useful, feel free to merge :-).

1. JSON Lines 
Sometimes a js file is hosted on a different domain than the one in the input file, so when having many source URLs it was difficult to know which URL the finding originated from. I implemented the `-jsl` flag that prints the output in JSON Lines, containing the source URL as well.
For example:
![image](https://github.com/lc/subjs/assets/21034728/3f74f7e4-ddfe-4043-9e87-759fa9b06fb4)

2. Cookies
I saw this was a requested feature so I implemented it.

3. Regex tweak
```golang
r := regexp.MustCompile(`[(\w./:)]*\.js`)
```

Not sure if this was intended but initially it also matched `js` and not only `.js`.
So strings like `blajs` were matched as well.

4. README.md
Changed the install command to use `go install` instead of `go get` and added the new flags.

Cheers! :-)